### PR TITLE
Add missing prerequisites when installing on Ubuntu Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ sudo apt install python3 python3-pip
 ``` 
 Also make sure that you have installed the following packets: 
  - libxext6
+ - libxi6
  - libxrender1
  - libxtst6
  - libfreetype6
    
 In Debian-based distributive you can install them using the command:
 ```bash
-sudo apt install libxext6 libxrender1 libxtst6 libfreetype6  
+sudo apt install libxext6 libxrender1 libxtst6 libfreetype6 libxi6  
 ```    
 
 To use [secure connection](#Secure-connection) feature you have to install OpenSSL utility:


### PR DESCRIPTION
Tested with Ubuntu Server 18.04 and 20.04