### PR TITLE
fix: CentOS dependency packages are incorrect for Centos 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ projector-installer make sure that:
     
     In CentOS use commands:
     ```bash
-    sudo yum install python36 python3-pip -y
     # CentOS 8+
-    sudo dnf install python3-pyOpenSSL python3-cryptography -y
+    sudo dnf install python39 python3-pip python3-pyOpenSSL python3-cryptography -y
     # CentOS 7 / Amazon Linux 2
-    sudo yum install pyOpenSSL python-cryptography -y
+    sudo yum install python36 python3-pip pyOpenSSL python-cryptography -y
     ```
 
 2. Update pip. 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ projector-installer make sure that:
    In Debian-based distributions you can install them using the command:
     ```bash
     sudo apt install python3 python3-pip -y
-    sudo apt install python3-crypto -y
+    sudo apt install python3-cryptography -y
     ```
     
     In CentOS use commands:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ projector-installer make sure that:
     In CentOS use commands:
     ```bash
     sudo yum install python36 python3-pip -y
-    sudo yum install pyOpenSSL python-cryptography -y 
+    # CentOS 8+
+    sudo dnf install python3-pyOpenSSL python3-cryptography -y
+    # CentOS 7 / Amazon Linux 2
+    sudo yum install pyOpenSSL python-cryptography -y
     ```
 
 2. Update pip. 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ projector-installer make sure that:
     In CentOS use commands:
     ```bash
     # CentOS 8+
-    sudo dnf install python39 python3-pip python3-pyOpenSSL python3-cryptography -y
+    sudo dnf install python3 python3-pip python3-pyOpenSSL python3-cryptography -y
     # CentOS 7 / Amazon Linux 2
-    sudo yum install python36 python3-pip pyOpenSSL python-cryptography -y
+    sudo yum install python3 python3-pip pyOpenSSL python-cryptography -y
     ```
 
 2. Update pip. 


### PR DESCRIPTION
Modified the dependency installation instructions as they were incorrect for CentOS 8. `pyOpenSSL` and `python-cryptography` don't exist, they are `python3-pyOpenSSL` and `python3-cryptography`. On Centos 7 and Amazon Linux 2, the current instructions are correct.

Personal preference, but on top of the package name differences I replaced the installer as `dnf` for CentOS 8 as `yum` is just a wrapper to `dnf` on that distro.

Also changed `python36` to `python3` as Amazon Linux2 doesn't have the package but it does have python3 (symlinked to 3.7) , and python3 is symlinked to python 3.6 on CentOS 7 and 8.

I didn't notice any error in the application, but let me know if this one is incorrect - switched `python3-crypto` with `python3-cryptography` in the Debian instructions, as Debian 11 doesn't have the package. Not sure what the impact of that change is but projector is running fine with that change.