### PR TITLE
Fixed a crash when installing certificate

### DIFF
--- a/projector_installer/actions.py
+++ b/projector_installer/actions.py
@@ -461,6 +461,7 @@ def do_install_cert(config_name: Optional[str], path_to_certificate: Optional[st
             print(f'Key file {path_to_key} does not exist. Exiting ...')
             sys.exit(1)
 
+        need_remove = False
         if not path_to_chain:
             path_to_chain = get_certificate_chain(path_to_certificate)
             need_remove = isfile(path_to_chain)


### PR DESCRIPTION
### Fixed a crash when installing a custom certificate after installing a self-signed certificate.
First install autogenerate certificate by this
`projector install-certificate AndroidStudio`

Crash occurs when updating to a custom certificate with chain later
`projector install-certificate AndroidStudio --certificate server.cert --key server.key --chain chain.pem`

The crash stack is as follows
```
Checking for updates ... done.
Installing server.csr certificate to config AndroidStudio
Traceback (most recent call last):
  File "/home/soar/.local/bin/projector", line 8, in <module>
    sys.exit(projector())
  File "/home/soar/.local/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/soar/.local/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/soar/.local/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/soar/.local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/soar/.local/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/soar/.local/lib/python3.6/site-packages/projector_installer/cmd.py", line 291, in install_certificate
    do_install_cert(config_name, certificate, key, chain)
  File "/home/soar/.local/lib/python3.6/site-packages/projector_installer/actions.py", line 470, in do_install_cert
    if need_remove:
UnboundLocalError: local variable 'need_remove' referenced before assignment
```