### PR TITLE
Sign certificates with a validity of 365 days.

### DIFF
--- a/projector_installer/secure_config.py
+++ b/projector_installer/secure_config.py
@@ -282,7 +282,7 @@ def get_projector_cert_sign_args(run_config: RunConfig) -> List[str]:
         '-ext', 'KeyUsage:critical=digitalSignature,keyEncipherment',
         '-ext', 'EKU=serverAuth',
         '-ext', f'SAN={get_projector_san("0.0.0.0", run_config.custom_names)}',
-        '-rfc', '-validity', '9999'
+        '-rfc', '-validity', '365'
     ]
 
 


### PR DESCRIPTION
Certificates signed with a validity of more than 397 will cause Chrome to refuse them with reason Certificate causing NET::ERR_CERT_VALIDITY_TOO_LONG .