### PR TITLE
Add python3-netifaces to CentOS prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ projector-installer make sure that:
     In CentOS use commands:
     ```bash
     # CentOS 8+
-    sudo dnf install python3 python3-pip python3-pyOpenSSL python3-cryptography -y
+    sudo dnf install python3 python3-pip python3-pyOpenSSL python3-cryptography python3-netifaces -y
     # CentOS 7 / Amazon Linux 2
     sudo yum install python3 python3-pip pyOpenSSL python-cryptography -y
     ```


### PR DESCRIPTION
`pip` tries to download and build the `netifaces` library but it fails unless we have installed the Python development headers, so it is easier to just use the distribution-provided binary package instead.