### PR TITLE
Update projector-server version to 1.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ bundled_dir = join(PACKAGE_DIR, BUNDLED_DIR)
 server_dir = join(bundled_dir, SERVER_DIR)
 
 PROJECTOR_SERVER_URL: str = 'https://github.com/JetBrains/projector-server/releases/' \
-                            'download/v1.7.0/projector-server-v1.7.0.zip'
+                            'download/v1.8.1/projector-server-v1.8.1.zip'
 
 
 def download_server(to_dir: str) -> None:


### PR DESCRIPTION
Under 1.8.1 version have serious bug. (PRJ-857)  
Why don't update it? Window disappeared bug possible give so bad experience to users.  
At this time, I use projector-server directly without installer due to not updated this project.